### PR TITLE
Adding DHT REST API support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,12 @@ struct Cli {
     /// Automatic shutdown after <SECONDS>
     #[arg(long = "shutdown-after")]
     seconds: Option<u64>,
+
+    /// Send alarms to the SIFIS-Home DHT REST interface
+    ///
+    /// The API URL is most likely http://localhost:3000/
+    #[arg(long, value_name = "API URL")]
+    dht: Option<String>,
 }
 
 /// Entry Point for the Server Program
@@ -65,11 +71,11 @@ async fn main() {
 
     // Creating State object for the server
     let state = if cli.db_path.is_none() && cli.runtime_path.is_none() {
-        NetspotControlState::new().await
+        NetspotControlState::new(cli.dht).await
     } else {
         let runtime_path = cli.runtime_path.unwrap_or(PathBuf::from("/tmp"));
         let db_path = cli.db_path.unwrap_or(Path::join(&runtime_path, "test.db"));
-        NetspotControlState::new_customized(&runtime_path, &db_path).await
+        NetspotControlState::new_customized(cli.dht, &runtime_path, &db_path).await
     };
     let state = match state {
         Ok(state) => state,

--- a/src/state/dht.rs
+++ b/src/state/dht.rs
@@ -1,0 +1,43 @@
+use crate::structures::dht::{DhtMessage, RequestPostTopicUUID};
+use crate::structures::statistics::Message;
+use crate::tasks::RunChecker;
+use tokio::sync::broadcast;
+
+pub async fn dht_message_sender(
+    api_url: String,
+    ip_addresses: Vec<String>,
+    mut message_rx: broadcast::Receiver<Message>,
+    mut run_checker: RunChecker,
+) {
+    println!("DHT message sender started.");
+    println!("  Using API URL: {api_url}");
+    while run_checker.keep_running() {
+        tokio::select! {
+            Ok(message) = message_rx.recv() => handle_message(&api_url, &ip_addresses, message).await,
+            _ = run_checker.shutdown_recv() => {},
+        }
+    }
+    println!("DHT message sender stopped.")
+}
+
+async fn handle_message(api_url: &str, ip_addresses: &[String], message: Message) {
+    match message {
+        Message::Alarm(message) => {
+            let dht_message = DhtMessage {
+                request_post_topic_uuid: RequestPostTopicUUID::new(ip_addresses, *message),
+            };
+            let json_message = serde_json::to_string(&dht_message);
+            if let Ok(message) = json_message {
+                tokio::spawn(send_message(api_url.to_string(), message));
+            }
+        }
+        Message::Data(_) => (), // Skipping these for now
+    }
+}
+
+async fn send_message(api_url: String, message: String) {
+    let client = reqwest::Client::new();
+    if let Err(err) = client.post(api_url).body(message).send().await {
+        eprintln!("{err}");
+    }
+}

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -1,4 +1,5 @@
 pub mod configuration;
+pub mod dht;
 pub mod statistics;
 pub mod status;
 pub mod webhooks;

--- a/src/structures/dht.rs
+++ b/src/structures/dht.rs
@@ -1,0 +1,44 @@
+use crate::structures::statistics::AlarmMessage;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DhtMessage {
+    pub request_post_topic_uuid: RequestPostTopicUUID,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RequestPostTopicUUID {
+    pub topic_name: String,
+    pub topic_uuid: String,
+    pub value: Value,
+}
+
+impl RequestPostTopicUUID {
+    pub fn new(addresses: &[String], alarm: AlarmMessage) -> Self {
+        RequestPostTopicUUID {
+            topic_name: "SIFIS:Netspot_Alarm".to_string(),
+            topic_uuid: "Netspot_Alarm".to_string(),
+            value: Value::new(addresses, alarm),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Value {
+    pub description: String,
+    pub addresses: Vec<String>,
+    pub alarm: AlarmMessage,
+}
+
+impl Value {
+    pub fn new(addresses: &[String], alarm: AlarmMessage) -> Self {
+        Value {
+            description: "Netspot Anomaly Alarm".to_string(),
+            addresses: addresses.to_owned(),
+            alarm,
+        }
+    }
+}

--- a/src/tests_common.rs
+++ b/src/tests_common.rs
@@ -20,7 +20,7 @@ impl TestSetup {
         test_db.push("test.db");
 
         // Creating state object
-        let state = NetspotControlState::new_customized(test_dir.path(), &test_db)
+        let state = NetspotControlState::new_customized(None, test_dir.path(), &test_db)
             .await
             .expect("Valid state object");
 


### PR DESCRIPTION
Alarm messages can now be sent to DHT REST API by introducing the "--dht <API_URL>" argument for the server application.